### PR TITLE
platform.hashing: add flags suggestions in package_info

### DIFF
--- a/recipes/platform.hashing/all/conanfile.py
+++ b/recipes/platform.hashing/all/conanfile.py
@@ -81,6 +81,6 @@ class PlatformInterfacesConan(ConanFile):
             }.get(str(self.settings.arch), "")
         self.user_info.suggested_flags = suggested_flags
 
-        if "-march" not in "{} {}".format(tools.get_env("CPPFLAGS", ""), tools.get_env("CPPFLAGS", "")):
-            self.output.warn("Platform.hashing needs to have `-march=ARCH` added to CPPFLAGS/CXXFLAGS.\n"
+        if "-march" not in "{} {}".format(tools.get_env("CPPFLAGS", ""), tools.get_env("CXXFLAGS", "")):
+            self.output.warn("platform.hashing needs to have `-march=ARCH` added to CPPFLAGS/CXXFLAGS."
                              "A suggestion is available in deps_user_info[{name}].suggested_flags.".format(name=self.name))

--- a/recipes/platform.hashing/all/conanfile.py
+++ b/recipes/platform.hashing/all/conanfile.py
@@ -48,22 +48,39 @@ class PlatformInterfacesConan(ConanFile):
                 self.name, self.settings.compiler))
 
         elif tools.Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration("platform.Hashing/{} "
-                                            "requires C++{} with {}, "
-                                            "which is not supported "
-                                            "by {} {}.".format(
-                self.version, self._minimum_cpp_standard, self.settings.compiler, self.settings.compiler,
+            raise ConanInvalidConfiguration("{}/{} requires c++{}, "
+                                            "which is not supported by {} {}.".format(
+                self.name, self.version, self._minimum_cpp_standard, self.settings.compiler,
                 self.settings.compiler.version))
 
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, self._minimum_cpp_standard)
 
+        if self.settings.arch in ("x86", ):
+            raise ConanInvalidConfiguration("{} does not support arch={}".format(self.name, self.settings.arch))
+
+    def package_id(self):
+        self.info.header_only()
+
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def package(self):
         self.copy("*.h", dst="include", src=self._internal_cpp_subfolder)
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
 
-    def package_id(self):
-        self.info.header_only()
+    def package_info(self):
+        self.cpp_info.libdirs = []
+        suggested_flags = ""
+        if self.settings.compiler != "Visual Studio":
+            suggested_flags = {
+                "x86_64": "-march=haswell",
+                "armv7": "-march=armv7",
+                "armv8": "-march=armv8-a",
+            }.get(str(self.settings.arch), "")
+        self.user_info.suggested_flags = suggested_flags
+
+        if "-march" not in "{} {}".format(tools.get_env("CPPFLAGS", ""), tools.get_env("CPPFLAGS", "")):
+            self.output.warn("Platform.hashing needs to have `-march=ARCH` added to CPPFLAGS/CXXFLAGS.\n"
+                             "A suggestion is available in deps_user_info[{name}].suggested_flags.".format(name=self.name))

--- a/recipes/platform.hashing/all/test_package/CMakeLists.txt
+++ b/recipes/platform.hashing/all/test_package/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package)
+project(test_package CXX)
+
+set(EXTRA_FLAGS "" CACHE STRING "Extra compiler flags")
+separate_arguments(EXTRA_FLAGS UNIX_COMMAND ${EXTRA_FLAGS})
+if(EXTRA_FLAGS)
+    add_compile_options(${EXTRA_FLAGS})
+endif()
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()

--- a/recipes/platform.hashing/all/test_package/conanfile.py
+++ b/recipes/platform.hashing/all/test_package/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+from conans.errors import ConanException
 import os
 
 
@@ -6,8 +7,19 @@ class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
 
+    @property
+    def _extra_flags(self):
+        return self.deps_user_info["platform.hashing"].suggested_flags
+
     def build(self):
+        if self.settings.compiler != "Visual Studio":
+            if not self._extra_flags:
+                raise ConanException("Suggested flags are not available for os={}/arch={}".format(self.settings.os, self.settings.arch))
+
         cmake = CMake(self)
+        if self.settings.compiler != "Visual Studio":
+            cmake.definitions["EXTRA_FLAGS"] = self._extra_flags
+        cmake.verbose = True
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Don't force `-march=...` on people, but warn users and maybe suggest a default.

I could not make it work for `arch=x86`.